### PR TITLE
Incluyendo .stylelintignore y index.html

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,2 @@
+_reset
+reset

--- a/index.html
+++ b/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="es">
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <title></title>
+        <meta name="description" content="">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <link rel="stylesheet" type="text/css" href="css/styles.css" inline>
+    </head>
+    <body>
+        <header>
+            <nav></nav>
+        </header>
+
+        <section>
+            <article></article>
+            <article></article>
+            <article></article>
+        </section>
+
+        <footer>
+
+        </footer>
+    </body>
+</html>


### PR DESCRIPTION
- Incluido `.stylelintignore` para que **Stylelint** no actúe sobre ciertos archivos como el `reset.css`
- Incluido `index.html` para ganar más tiempo y crear un archivo básico. Este archivo incluye una etiqueta `inline`en el <link` para así poder meter en línea aquellos **CSS** que cumplan una serie de atributos.