### PR TITLE
modificando la ruta para que lint staged solo lintee los css de src

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "author": "Jorge Aznar",
   "lint-staged": {
-    "*.css": "stylelint"
+    "src/css/*.css": "stylelint"
   },
   "pre-commit": "lint-staged",
   "scripts": {


### PR DESCRIPTION
Al comprimir con CSSnano y luego pasar lint-staged el CSS generado daba errores con stylelint, demasiados errores. Ahora lint-staged solo actuará sobre los CSS que esten alojado en `src/css/`